### PR TITLE
Handle timeout

### DIFF
--- a/othpc/submit_function.py
+++ b/othpc/submit_function.py
@@ -106,15 +106,23 @@ class SubmitFunction(ot.OpenTURNSPythonFunction):
         if not task_number < len(X):
             return [float("nan")] * self.getOutputDimension()
 
+        # Write input to CSV file for future reference
+        x = X[task_number]
+        input_as_sample = ot.Sample([x])
+        input_as_sample.setDescription(self.getInputDescription())
+        folder = os.path.join("logs", jobid)
+        input_file = os.path.join(folder, f"{jobid}_{task_number}_input.csv")
+        input_as_sample.exportToCSVFile(input_file)
+
         # Actual call to the callable
-        output = self.callable(X[task_number])
+        output = self.callable(x)
 
         # Save output to CSV file in case the job fails
         # because some other task fails
         output_as_sample = ot.Sample([output])
-        folder = os.path.join("logs", jobid)
-        file = os.path.join(folder, f"{jobid}_{task_number}_output.csv")
-        output_as_sample.exportToCSVFile(file)
+        output_as_sample.setDescription(self.getOutputDescription())
+        output_file = os.path.join(folder, f"{jobid}_{task_number}_output.csv")
+        output_as_sample.exportToCSVFile(output_file)
 
         return output
 


### PR DESCRIPTION
This PR is designed to handle jobs running into the SLURM walltime:

- We use a try/except mechanism around the `submitit` `jobs.results()` command in case the results are not available due to the timeout.
- The `task` wrapper around the `callable` now writes the output in the relevant log folder as a CSV file, so that it can be read later. This is useful in cases where a single task within a job fails: in such cases `submitit` is unable to retrieve *any* of the task results, so we read them from CSV files instead.
- The same `task` wrapper also writes the input in the same log folder to make debugging easier.